### PR TITLE
Fix id property

### DIFF
--- a/src/schemas/json/bitrise.json
+++ b/src/schemas/json/bitrise.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/BitriseDataModel",
+  "$id": "https://json.schemastore.org/bitrise.json",
   "definitions": {
     "AppModel": {
       "properties": {
@@ -522,6 +523,5 @@
       "additionalProperties": false,
       "type": "object"
     }
-  },
-  "id": "https://json.schemastore.org/bitrise.json"
+  }
 }


### PR DESCRIPTION
This PR fixes the bitrise.yml schema's id property: `id` should be `$id` from draft-06.